### PR TITLE
Fix tablet home UI

### DIFF
--- a/app/assets/style_sheets/mobile/horizontalCardComponentStyles.js
+++ b/app/assets/style_sheets/mobile/horizontalCardComponentStyles.js
@@ -1,29 +1,35 @@
 import { StyleSheet } from 'react-native';
-import {
-  cardBorderRadius,
-  cardTitleFontSize,
-  descriptionFontSize
-} from '../../../constants/component_constant';
+import {cardBorderRadius} from '../../../constants/component_constant';
 import color from '../../../themes/color';
+import {FontSetting} from '../../../assets/style_sheets/font_setting';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
     borderRadius: cardBorderRadius,
-    // height: 112,
-    // height: 142,
-    paddingLeft: 12,
-    paddingRight: 4,
+    height: 110,
+    paddingHorizontal: 12,
     width: '100%',
   },
+  labelContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 8
+  },
   title: {
-    fontSize: cardTitleFontSize
+    fontSize: FontSetting.title
+  },
+  rightBtnContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
   },
   startLabel: {
-    fontSize: descriptionFontSize,
-    color: color.primaryColor
+    color: color.primaryColor,
+    marginRight: 4,
+    fontSize: FontSetting.text,
   },
   arrowIcon: {
-    color: color.arrowIcon
+    color: color.pressable
   }
 });
 

--- a/app/assets/style_sheets/mobile/horizontalCardImageComponentStyles.js
+++ b/app/assets/style_sheets/mobile/horizontalCardImageComponentStyles.js
@@ -1,20 +1,15 @@
 import { StyleSheet } from 'react-native';
-import { cardBorderRadius } from '../../../constants/component_constant';
+import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
 
 const HorizontalCardImageComponentStyles = StyleSheet.create({
   container:{
-    flex: 2,
-    height: 110
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: wp('26%')
   },
   image: {
-    // borderRadius: cardBorderRadius,
-    // elevation: 6,
-    // width: '100%',
-    // height: '100%',
     width: 105,
     height: 86,
-    // position: 'absolute',
-    // top: -16,
   }
 });
 

--- a/app/assets/style_sheets/mobile/titledCardComponentStyles.js
+++ b/app/assets/style_sheets/mobile/titledCardComponentStyles.js
@@ -1,13 +1,12 @@
 import {StyleSheet, Platform} from 'react-native';
 import color from '../../../themes/color';
-import {cardTitleFontSize} from '../../../constants/component_constant';
 import componentUtil from '../../../utils/component_util';
-import {isLowPixelDensityDevice} from '../../../utils/responsive_util';
+import {isLowPixelDensityDevice, isShortScreenDevice} from '../../../utils/responsive_util';
+import {FontSetting} from '../../../assets/style_sheets/font_setting';
 
 const tiltedCardComponentStyles = StyleSheet.create({
   container: {
-    maxHeight: 160,
-    // maxHeight: 246,
+    maxHeight: isShortScreenDevice() ? 140 : 155,
     width: componentUtil.getGridCardWidth(),
     borderRadius: 70
   },
@@ -52,15 +51,13 @@ const tiltedCardComponentStyles = StyleSheet.create({
     flexDirection: 'column',
     flexGrow: 1,
   },
-  title: {
-    fontSize: cardTitleFontSize,
-    // flex: 1,
-    paddingHorizontal: 8,
+  titleContainer: {
+    alignItems: 'center',
+    top: isShortScreenDevice() ? -15 : -20
   },
-  footer: {
-    // flex: 3,
-    backgroundColor: 'yellow'
-    // paddingTop: 8
+  title: {
+    fontSize: FontSetting.title,
+    paddingHorizontal: 8,
   }
 });
 

--- a/app/assets/style_sheets/tablet/horizontalCardComponentStyles.js
+++ b/app/assets/style_sheets/tablet/horizontalCardComponentStyles.js
@@ -1,12 +1,13 @@
 import { StyleSheet, Platform } from 'react-native';
 import { cardBorderRadius } from '../../../constants/component_constant';
 import {getiPadStyle, getAndroidTabletStyle} from '../../../utils/responsive_util';
+import color from '../../../themes/color'
+import {FontSetting} from '../../../assets/style_sheets/font_setting';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
     borderRadius: cardBorderRadius,
-    paddingLeft: 12,
-    paddingRight: 4,
+    paddingHorizontal: 16,
     width: '100%',
     ...Platform.select({
       ios: {
@@ -16,6 +17,27 @@ const horizontalCardComponentStyles = StyleSheet.create({
         height: getAndroidTabletStyle(115, 130),
       }
     })
+  },
+  labelContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+  },
+  title: {
+    fontSize: FontSetting.title
+  },
+  rightBtnContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  startLabel: {
+    color: color.pressable,
+    marginRight: 4,
+    fontSize: FontSetting.text
+  },
+  arrowIcon: {
+    color: color.pressable
   }
 });
 

--- a/app/assets/style_sheets/tablet/horizontalCardImageComponentStyles.js
+++ b/app/assets/style_sheets/tablet/horizontalCardImageComponentStyles.js
@@ -1,17 +1,15 @@
 import { StyleSheet } from 'react-native';
-import { cardBorderRadius } from '../../../constants/component_constant';
+import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
 
 const HorizontalCardImageComponentStyles = StyleSheet.create({
   container:{
-    flex: 1
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: wp('22%'),
   },
   image: {
-    borderRadius: cardBorderRadius,
-    elevation: 6,
     width: '100%',
-    height: '103%',
-    position: 'absolute',
-    top: -16,
+    height: hp('10%')
   }
 });
 

--- a/app/assets/style_sheets/tablet/titledCardComponentStyles.js
+++ b/app/assets/style_sheets/tablet/titledCardComponentStyles.js
@@ -1,8 +1,8 @@
-import {StyleSheet, Platform, Dimensions} from 'react-native';
+import {StyleSheet, Platform} from 'react-native';
 import color from '../../../themes/color';
-import {cardTitleFontSize} from '../../../constants/component_constant';
 import componentUtil from '../../../utils/component_util';
 import {getiPadStyle, getAndroidTabletStyle} from '../../../utils/responsive_util';
+import {FontSetting} from '../../../assets/style_sheets/font_setting';
 
 const titledCardComponentStyles = StyleSheet.create({
   container: {
@@ -67,9 +67,12 @@ const titledCardComponentStyles = StyleSheet.create({
     flexDirection: 'column',
     flexGrow: 1,
   },
+  titleContainer: {
+    alignItems: 'center',
+    top: -30
+  },
   title: {
-    fontSize: cardTitleFontSize,
-    flex: 1,
+    fontSize: FontSetting.title,
     lineHeight: 27,
     paddingHorizontal: 8,
     ...Platform.select({
@@ -77,10 +80,6 @@ const titledCardComponentStyles = StyleSheet.create({
         paddingTop: 8,
       }
     })
-  },
-  footer: {
-    flex: 3,
-    paddingTop: 8
   }
 });
 

--- a/app/components/home/HomeNavigationHeader.js
+++ b/app/components/home/HomeNavigationHeader.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import {View, StyleSheet, Image} from 'react-native'
+import {Appbar} from 'react-native-paper';
+
+import { FontSetting } from '../../assets/style_sheets/font_setting';
+import {FontFamily} from '../../themes/font';
+import {screenHorizontalPadding} from '../../constants/component_constant';
+
+const HomeNavigationHeader = () => {
+  return (
+    <Appbar.Header style={[styles.header]}>
+      <View style={{flexDirection: 'row', alignItems: 'center', width: '100%'}}>
+        <Image source={require('../../assets/images/logo.png')} style={{width: 40, height: 40, marginLeft: screenHorizontalPadding - 4}} />
+        <Appbar.Content title='ត្រីវិស័យ' titleStyle={styles.title} numberOfLines={1} />
+      </View>
+    </Appbar.Header>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    backgroundColor: 'white',
+    elevation: 1,
+  },
+  title: {
+    color: 'black',
+    fontFamily: FontFamily.regular,
+    fontSize: FontSetting.nav_title,
+  }
+})
+
+export default HomeNavigationHeader

--- a/app/components/shared/GradientScrollViewComponent.js
+++ b/app/components/shared/GradientScrollViewComponent.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-// import LinearGradient from 'react-native-linear-gradient';
 import {backgroundColors} from '../../themes/color';
 import {screenHorizontalPadding, gradientScrollViewBigPaddingBottom} from '../../constants/component_constant';
 
@@ -14,7 +13,7 @@ const GradientScrollViewComponent = (props) => {
       { props.isNotScrollView ?
           props.body
         :
-        <ScrollView contentContainerStyle={[styles.scrollView, props.scrollViewStyle]}
+        <ScrollView contentContainerStyle={[styles.scrollView,props.scrollViewStyle]}
           nestedScrollEnabled={true}
           scrollEnabled={props.scrollable ?? true}
           scrollEventThrottle={16}
@@ -31,7 +30,7 @@ const styles = StyleSheet.create({
   scrollView: {
     flexGrow: 1,
     paddingHorizontal: screenHorizontalPadding,
-    // paddingBottom: gradientScrollViewBigPaddingBottom
+    paddingBottom: gradientScrollViewBigPaddingBottom
   }
 });
 

--- a/app/components/shared/cards/HorizontalCard/HorizontalCardComponent.js
+++ b/app/components/shared/cards/HorizontalCard/HorizontalCardComponent.js
@@ -19,20 +19,14 @@ const HorizontalCardComponent = (props) => {
 
   return (
     <Card style={[styles.container, props.containerStyle]} onPress={() => onPress()} >
-      <View style={{flexDirection: 'row'}}>
-        <View style={{}}>
-          <HorizontalCardImageComponent image={props.item.source_image} />
-        </View>
-
-        <View style={{flexGrow: 1, justifyContent: 'center', marginHorizontal: 4}}>
+      <View style={{flexDirection: 'row', height: '100%'}}>
+        <HorizontalCardImageComponent image={props.item.source_image} />
+        <View style={styles.labelContainer}>
           <BoldLabelComponent label={props.item.title} numberOfLines={2} style={styles.title} />
         </View>
-
-        <View style={{justifyContent: 'center'}}>
-          <View style={{flexDirection: 'row', alignItems: 'center'}}>
-            <Text style={styles.startLabel}>ចាប់ផ្តើម</Text>
-            <Icon name="chevron-right" size={24} style={[styles.arrowIcon, {marginHorizontal: 4}]}/>
-          </View>
+        <View style={styles.rightBtnContainer}>
+          <Text style={styles.startLabel}>ចាប់ផ្តើម</Text>
+          <Icon name="chevron-right" size={24} style={styles.arrowIcon}/>
         </View>
       </View>
     </Card>

--- a/app/components/shared/cards/HorizontalCard/HorizontalCardImageComponent.js
+++ b/app/components/shared/cards/HorizontalCard/HorizontalCardImageComponent.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Image, StyleSheet } from 'react-native';
+import { View, Image } from 'react-native';
 
 import { getStyleOfDevice } from '../../../../utils/responsive_util';
 import tabletStyles from '../../../../assets/style_sheets/tablet/horizontalCardImageComponentStyles';
@@ -10,23 +10,9 @@ const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 const HorizontalCardImageComponent = (props) => {
   return (
     <View style={styles.container}>
-      <View style={sts.imageContainer}>
-        <Image source={props.image}
-          resizeMode='center'
-          style={styles.image}
-        />
-      </View>
+    <Image source={props.image} resizeMode='center' style={styles.image} />
     </View>
   )
 }
-
-const sts = StyleSheet.create({
-  imageContainer: {
-    width: 105,
-    marginTop: 12,
-    justifyContent: 'center',
-    alignItems: 'center',
-  }
-})
 
 export default HorizontalCardImageComponent;

--- a/app/components/shared/cards/TitledCard/TitledCardComponent.js
+++ b/app/components/shared/cards/TitledCard/TitledCardComponent.js
@@ -32,10 +32,8 @@ const TitledCardComponent = (props) => {
 
       <View style={styles.backgroundContainer}>
         <View style={styles.infoContainer}>
-
           <TiltedCardImageComponent image={props.item.source_image} />
-
-          <View style={{top: -30, alignItems: 'center'}}>
+          <View style={styles.titleContainer}>
             <BoldLabelComponent label={props.item.title} numberOfLines={2} style={styles.title} />
           </View>
         </View>

--- a/app/components/shared/cards/TitledCard/TitledCardImageComponent.js
+++ b/app/components/shared/cards/TitledCard/TitledCardImageComponent.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {View, StyleSheet, Image} from 'react-native';
+import {getStyleOfDevice} from '../../../../utils/responsive_util'
 
 const TitledCardImageComponent = (props) => {
   return <View style={{flex: 1.5}}>
@@ -9,7 +10,7 @@ const TitledCardImageComponent = (props) => {
 
 const styles = StyleSheet.create({
   image: {
-    height: 115,
+    height: getStyleOfDevice(125, 115),
     width: '100%',
     top: -46,
     zIndex: 1,

--- a/app/navigations/AppNavigator.js
+++ b/app/navigations/AppNavigator.js
@@ -29,13 +29,8 @@ function HomeTab() {
       tabBarLabelStyle: { lineHeight: Platform.OS == 'android' ? 20 : 0}
     }}>
       <Tab.Screen name="Home" component={HomeScreen} options={{
-        headerShown: true,
-        title: "ត្រីវិស័យ",
         tabBarLabel: 'ទំព័រដេីម',
         tabBarIcon: ({ focused, horizontal, tintColor }) => (<MaterialIcon name='home' size={22} color={tintColor} />),
-        headerLeft: () => (
-          <Image source={require('../assets/images/logo.png')} style={{width: 40, height: 40, marginLeft: 16}} />
-        ),
       }} />
       {/*<Tab.Screen name="Profile" component={ProfileStack} options={{
         tabBarLabel: 'ប្រវត្តិរូបសង្ខេប',

--- a/app/screens/home/HomeScreen.js
+++ b/app/screens/home/HomeScreen.js
@@ -12,7 +12,7 @@ const HomeScreen = ({navigation}) => {
 
   const renderBody = () => {
     return (
-      <View style={{ flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between'}}>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between', paddingBottom: 16}}>
         { home_categories.map((item, index) =>
           <CardItemComponent key={index} item={item} onPress={() => onPress(item)}/>
         )}

--- a/app/screens/home/HomeScreen.js
+++ b/app/screens/home/HomeScreen.js
@@ -2,6 +2,7 @@ import React from 'react';
 import GradientScrollViewComponent from '../../components/shared/GradientScrollViewComponent';
 import CardItemComponent from '../../components/shared/cards/CardItemComponent';
 import home_categories from '../../components/home/home_categories';
+import HomeNavigationHeader from '../../components/home/HomeNavigationHeader'
 import { View } from 'react-native';
 
 const HomeScreen = ({navigation}) => {
@@ -22,7 +23,7 @@ const HomeScreen = ({navigation}) => {
 
   return (
     <GradientScrollViewComponent
-      header={<></>}
+      header={<HomeNavigationHeader/>}
       body={ renderBody() }
     />
   )

--- a/app/themes/color.js
+++ b/app/themes/color.js
@@ -34,6 +34,7 @@ const Color = {
   grayStatusBar: 'rgba(0, 0, 0, 0.251)',
   borderColor: '#808080',
   paleGray: '#e6e7e9',
+  pressable: '#1876D3'
 }
 
 export default Color;


### PR DESCRIPTION
This pull request fixes the style and makes some enhancements to the home screen:
- Fix the style of the card item when open on tablet devices (iOS & Android)
- Create a navigation header component for the home screen to make the nav header padding and margin consistent with other screens and to fix the style break when open on iPhone with a notch

Below are the screenshots of the home screen on mobile and tablet devices (iOS & Android):
[TreyVisay - home.zip](https://github.com/ilabsea/trey-visay/files/11612092/TreyVisay.-.home.zip)
