### PR TITLE
Update FLIPPER_VERSION from 0.125.0 to 0.144.0 to fix the app crash o…

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -25,7 +25,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.125.0
+FLIPPER_VERSION=0.144.0
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using


### PR DESCRIPTION
This pull request updates the FLIPPER_VERSION from 0.125.0 to 0.144.0 to fix the app crash when running on the Android emulator and removes the yarn.lock file.