### PR TITLE
Fix holland questionnaire nav header

### DIFF
--- a/app/assets/style_sheets/scroll_header.js
+++ b/app/assets/style_sheets/scroll_header.js
@@ -49,7 +49,8 @@ export default StyleSheet.create({
     lineHeight: 22
   },
   iconText: {
-    fontSize: 20,
+    fontSize: FontSetting.text,
+    fontWeight: 'bold',
     color: 'rgb(24,118,211)'
   },
   line: {

--- a/app/components/HollandTest/RatingGroup.js
+++ b/app/components/HollandTest/RatingGroup.js
@@ -4,6 +4,7 @@ import Rating from './Rating';
 import { useFormikContext } from "formik";
 import ErrorMessage from '../forms/ErrorMessage';
 import Text from '../Text';
+import {FontSetting} from '../../assets/style_sheets/font_setting';
 
 const RatingGroup = ({name, options}) => {
   const { setFieldValue, values, errors, touched, isSubmitting } = useFormikContext();
@@ -14,7 +15,7 @@ const RatingGroup = ({name, options}) => {
       <TouchableOpacity onPress={() => {
         setFieldValue(name, rating.value);
       }} key={index} style={{justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap'}}>
-        <Text style={{fontSize: 10}}>{rating.name}</Text>
+        <Text style={{fontSize: 12}}>{rating.name}</Text>
         <Rating icon={rating.icon} style={{width: 40, height: 40}} active={rating.value == value} />
       </TouchableOpacity>
     )

--- a/app/components/HollandTestResult/HollandTestResultAccordionContent.js
+++ b/app/components/HollandTestResult/HollandTestResultAccordionContent.js
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { Text } from '../../components';
 import Color from '../../themes/color';
 import { FontSetting } from '../../assets/style_sheets/font_setting';
+import {FontFamily} from '../../themes/font';
 
 const HollandTestResultAccordionContent = (props) => {
   const renderContent = () => {
@@ -16,7 +17,7 @@ const HollandTestResultAccordionContent = (props) => {
     return sections.map((section, index) => {
       return (
         <View key={index}>
-          <Text style={{fontSize: FontSetting.small_text, marginTop: index == 0 ? 6 : 10, marginBottom: -4, color: Color.grayColor}}>{section.title}</Text>
+          <Text style={{color: Color.gray, marginTop: index == 0 ? 6 : 12, fontFamily: FontFamily.bold}}>{section.title}</Text>
           <Text style={{color: 'black'}}>{section.description}</Text>
         </View>
       )

--- a/app/components/footer/FooterBar.js
+++ b/app/components/footer/FooterBar.js
@@ -4,6 +4,7 @@ import { Footer, Button } from 'native-base';
 import {screenHorizontalPadding} from '../../constants/component_constant';
 import {getStyleOfDevice} from '../../utils/responsive_util';
 import Text from '../Text';
+import { FontSetting } from '../../assets/style_sheets/font_setting';
 
 const FooterBar = (props) => {
   return(
@@ -28,7 +29,8 @@ const styles = StyleSheet.create({
   },
   btnText: {
     color: '#fff',
-    marginTop: getStyleOfDevice(-3, -1)
+    marginTop: getStyleOfDevice(-3, -1),
+    fontSize: FontSetting.button_text,
   },
 })
 

--- a/app/components/scrollableHeaders/ScrollableHeaderNavigation.js
+++ b/app/components/scrollableHeaders/ScrollableHeaderNavigation.js
@@ -9,7 +9,7 @@ const ScrollableHeaderNavigation = (props) => {
   if (!props.renderNavigation)
     return null
 
-  return <CustomNavigationHeader headerStyle={styles.bar}/>
+  return <CustomNavigationHeader headerStyle={styles.bar} buttonColor={props.buttonColor}/>
 }
 
 const iosTop = getStyleOfDevice(29, DeviceInfo.hasNotch() ? 56 : 26)

--- a/app/components/scrollable_header.js
+++ b/app/components/scrollable_header.js
@@ -74,6 +74,7 @@ class ScrollableHeader extends Component {
               scrollY={this.state.scrollY}
               headerMaxHeight={this.props.headerMaxHeight}
               renderNavigation={this.props.renderNavigation}
+              buttonColor={this.props.buttonColor}
            />
   }
 

--- a/app/components/shared/ConfirmationModals/ConfirmationModalButtons.js
+++ b/app/components/shared/ConfirmationModals/ConfirmationModalButtons.js
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     height: pressableItemSize,
     minWidth: pressableItemSize,
-    paddingHorizontal: 12
+    paddingHorizontal: 18
   }
 });
 

--- a/app/components/shared/CustomNavigationHeader.js
+++ b/app/components/shared/CustomNavigationHeader.js
@@ -12,7 +12,7 @@ const CustomNavigationHeader = (props) => {
   return (
     <Appbar.Header style={[styles.header, props.headerStyle]}>
       <View style={{flexDirection: 'row', alignItems: 'center', width: '100%'}}>
-        <BackButton onPress={() => !!props.onPressBack ? props.onPressBack() : goBack()} />
+        <BackButton onPress={() => !!props.onPressBack ? props.onPressBack() : goBack()} buttonColor={props.buttonColor} />
         <Appbar.Content title={props.title} titleStyle={styles.title} numberOfLines={1} />
       </View>
       {props.children}

--- a/app/screens/HollandTest/HollandInstructionScreen.js
+++ b/app/screens/HollandTest/HollandInstructionScreen.js
@@ -52,6 +52,7 @@ const HollandTestInstruction = ({route, navigation}) => {
         renderNavigation={ renderNavigation }
         title={'តេស្តបុគ្គលិកលក្ខណៈ'}
         largeTitle={'តេស្តបុគ្គលិកលក្ខណៈ'}
+        buttonColor={Color.whiteColor}
       />
 
       <ConfirmationModal

--- a/app/screens/HollandTest/HollandQuestionnaireScreen.js
+++ b/app/screens/HollandTest/HollandQuestionnaireScreen.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import { View, TouchableOpacity } from 'react-native'
+import { View, TouchableOpacity, ScrollView } from 'react-native'
 import {
   Text,
   BackButton,
@@ -11,6 +11,7 @@ import {
 import Color from '../../themes/color';
 import scrollHeaderStyles from '../../assets/style_sheets/scroll_header';
 import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
+import HollandQuestionNavHeader from './components/HollandQuestionNavHeader';
 import HollandQuestionItem from './components/HollandQuestionItem';
 import Quiz from '../../models/Quiz';
 import { Form, SubmitButton } from '../../components/forms';
@@ -60,38 +61,20 @@ export default HollandQuestionnaireScreen = ({route, navigation}) => {
     )
   }
 
-  const renderNavigation = () => {
-    return (
-      <View style={{flexDirection: 'row', alignItems: 'center'}}>
-        <BackButton buttonColor='#fff' style={{width: 48}}/>
-        <Text style={[scrollHeaderStyles.navTitle, { paddingTop: 2, flex: 1,  justifyContent: 'center' }]}>តេស្តបុគ្គលិកលក្ខណៈ</Text>
-
-        <TouchableOpacity onPress={() => {}} style={{padding: 16}}>
-          <AwesomeIcon name='home' color={Color.whiteColor} size={28} />
-        </TouchableOpacity>
-      </View>
-    )
-  }
-
   return (
     <Form
       initialValues={initialValues}
       onSubmit={ handleSubmit }
-      validationSchema={validationSchema} >
-
-      <View style={{flex: 1}}>
-        <ScrollableHeader
-          backgroundColor={Color.blue}
-          statusBarColor={Color.blueStatusBar}
-          barStyle={'light-content'}
-          renderContent={ renderContent }
-          renderNavigation={ renderNavigation }
-          headerMaxHeight={140}
-          renderForeground={ () => <ProgressStep step={page} /> }
-        />
-
-        <SubmitButton title='បន្តទៀត' />
-      </View>
+      validationSchema={validationSchema}
+    >
+      <HollandQuestionNavHeader/>
+      <ScrollView contentContainerStyle={{flexGrow: 1}}>
+        <View style={{backgroundColor: Color.blue, paddingHorizontal: 16, paddingTop: 8}}>
+          <ProgressStep step={page}/>
+        </View>
+        {renderContent()}
+      </ScrollView>
+      <SubmitButton title='បន្តទៀត' />
     </Form>
   )
 }

--- a/app/screens/HollandTest/components/HollandQuestionNavHeader.js
+++ b/app/screens/HollandTest/components/HollandQuestionNavHeader.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import {View, StyleSheet} from 'react-native'
+import {Appbar} from 'react-native-paper';
+
+import {BackButton, Text} from '../../../components'
+import ConfirmationModal from '../../../components/shared/ConfirmationModal';
+
+import {goBack, reset} from '../../../hooks/RootNavigation'
+import { FontSetting } from '../../../assets/style_sheets/font_setting';
+import {FontFamily} from '../../../themes/font';
+import Color from '../../../themes/color';
+import {getStyleOfOS, getStyleOfDevice} from '../../../utils/responsive_util'
+
+const CustomNavigationHeader = (props) => {
+  const [modalVisible, setModalVisible] = React.useState(false)
+
+  const renderConfirmation = () => {
+    const message = (
+      <React.Fragment>
+        <Text>រាល់ចម្លើយដែលអ្នកបានជ្រើសរើសនឹងត្រូវបាត់បង់នៅពេលចាក់ចេញ។</Text>
+        <Text style={{marginTop: 12}}>តើអ្នកពិតជាចង់ចាកចេញពីការតេស្តនេះមែន ឬទេ?</Text>
+      </React.Fragment>
+    )
+
+    return <ConfirmationModal
+              visible={modalVisible}
+              leftButtonLabel='ទេ'
+              rightButtonLabel='បាទ/ចាស'
+              onLeftPress={() => setModalVisible(false)}
+              onRightPress={() => reset({routeName: 'HomeTab', params: {}})}
+              message={() => message}
+              onDismiss={() => setModalVisible(false)}
+            />
+  }
+
+  return (
+    <React.Fragment>
+      <Appbar.Header style={{backgroundColor: Color.blue}}>
+        <View style={{flexDirection: 'row', alignItems: 'center', width: '100%'}}>
+          <BackButton onPress={() => !!props.onPressBack ? props.onPressBack() : goBack()} buttonColor={Color.whiteColor} />
+          <Appbar.Content title='តេស្តបុគ្គលិកលក្ខណៈ' titleStyle={styles.title} numberOfLines={1} />
+          <Appbar.Action icon="home" onPress={() => setModalVisible(true)} color={Color.whiteColor} size={getStyleOfOS(getStyleOfDevice(28, 24), 24)} />
+        </View>
+      </Appbar.Header>
+      {renderConfirmation()}
+    </React.Fragment>
+  )
+}
+
+const styles = StyleSheet.create({
+  title: {
+    color: Color.whiteColor,
+    fontFamily: FontFamily.regular,
+    fontSize: FontSetting.nav_title,
+  }
+})
+
+export default CustomNavigationHeader

--- a/app/screens/HollandTest/components/ResumeQuizButton.js
+++ b/app/screens/HollandTest/components/ResumeQuizButton.js
@@ -69,6 +69,5 @@ const styles = StyleSheet.create({
   btnText: {
     fontSize: FontSetting.button_text,
     color: '#fff',
-    fontWeight: 'bold'
   }
 });

--- a/app/screens/HollandTest/components/StartQuizButton.js
+++ b/app/screens/HollandTest/components/StartQuizButton.js
@@ -71,6 +71,5 @@ const styles = StyleSheet.create({
   btnText: {
     fontSize: FontSetting.button_text,
     color: '#fff',
-    fontWeight: 'bold'
   }
 });

--- a/app/screens/PersonalUnderstanding/PersonalUnderstandingTest.js
+++ b/app/screens/PersonalUnderstanding/PersonalUnderstandingTest.js
@@ -77,6 +77,7 @@ export default PersonalUnderstandingTest = ({navigation}) => {
           renderNavigation={ renderNavigation }
           title={'ស្វែងយល់ពីខ្លួនឯង'}
           largeTitle={'ស្វែងយល់ពីខ្លួនឯង'}
+          buttonColor={Color.whiteColor}
         />
 
         { <SubmitButton title="បន្តទៀត"/> }


### PR DESCRIPTION
This pull request makes some enhancements to the Holland questionnaire screen as listed below:
- Update the navigation header and make adjustments to the progress step component of the Holland questionnaire screen
- Add a return home button (with confirmation dialog) in the Holland questionnaire navigation header
- Increase the font size of the emoji label
- Make the font size and font weight of the buttons in the Holland home screen consistent with the footer button
- Change the color of the header back button of the Holland home and Holland instruction screens
- Update the accordion section title of the Holland test result to look consistent with the Major detail accordion

Below are the screenshots of the Holland home, Holland instruction, and Holland questionnaire screens:
[holland questionnaire.zip](https://github.com/ilabsea/trey-visay/files/11703102/holland.questionnaire.zip)