### PR TITLE
Show progress step arrow style

### DIFF
--- a/app/components/HollandTest/ProgressStep.js
+++ b/app/components/HollandTest/ProgressStep.js
@@ -52,7 +52,7 @@ export default class ProgressStep extends Component {
     }
 
     return (
-      <View style={{ width: '100%', flexDirection: 'row', alignItems: 'center', marginBottom: 18}}>
+      <View style={{ width: '100%', flexDirection: 'row', alignItems: 'center', marginBottom: 12}}>
         { doms }
       </View>
     )

--- a/app/components/HollandTest/RatingGroup.js
+++ b/app/components/HollandTest/RatingGroup.js
@@ -1,10 +1,10 @@
-import React, {useState} from 'react'
+import React from 'react'
 import { View, TouchableOpacity } from 'react-native'
 import Rating from './Rating';
 import { useFormikContext } from "formik";
 import ErrorMessage from '../forms/ErrorMessage';
 import Text from '../Text';
-import {FontSetting} from '../../assets/style_sheets/font_setting';
+import {isShortWidthScreen} from '../../utils/responsive_util';
 
 const RatingGroup = ({name, options}) => {
   const { setFieldValue, values, errors, touched, isSubmitting } = useFormikContext();
@@ -15,7 +15,7 @@ const RatingGroup = ({name, options}) => {
       <TouchableOpacity onPress={() => {
         setFieldValue(name, rating.value);
       }} key={index} style={{justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap'}}>
-        <Text style={{fontSize: 12}}>{rating.name}</Text>
+        <Text style={{fontSize: isShortWidthScreen() ? 11 : 12}}>{rating.name}</Text>
         <Rating icon={rating.icon} style={{width: 40, height: 40}} active={rating.value == value} />
       </TouchableOpacity>
     )
@@ -27,7 +27,7 @@ const RatingGroup = ({name, options}) => {
         { options.map(renderRating) }
       </View>
 
-      <ErrorMessage error={errors[name]} visible={touched[name]} />
+      <ErrorMessage error={errors[name]} visible={touched[name]} style={{marginLeft: 16}} />
     </View>
   )
 }

--- a/app/screens/HollandTest/HollandQuestionnaireScreen.js
+++ b/app/screens/HollandTest/HollandQuestionnaireScreen.js
@@ -69,7 +69,7 @@ export default HollandQuestionnaireScreen = ({route, navigation}) => {
       onSubmit={ handleSubmit }
       validationSchema={validationSchema}
     >
-      <HollandQuestionNavHeader/>
+      <HollandQuestionNavHeader step={page}/>
       <ScrollView contentContainerStyle={{flexGrow: 1}}>
         <View style={{backgroundColor: Color.blue, paddingHorizontal: 16, paddingTop: 8}}>
           <ProgressStep step={page}/>

--- a/app/screens/HollandTest/HollandQuestionnaireScreen.js
+++ b/app/screens/HollandTest/HollandQuestionnaireScreen.js
@@ -1,16 +1,7 @@
-import React, {useState} from 'react'
-import { View, TouchableOpacity, ScrollView } from 'react-native'
-import {
-  Text,
-  BackButton,
-  BackConfirmDialog,
-  ProgressStep,
-  ScrollableHeader,
-} from '../../components';
+import React from 'react'
+import { Animated, View } from 'react-native'
+import DeviceInfo from 'react-native-device-info'
 
-import Color from '../../themes/color';
-import scrollHeaderStyles from '../../assets/style_sheets/scroll_header';
-import AwesomeIcon from 'react-native-vector-icons/FontAwesome';
 import HollandQuestionNavHeader from './components/HollandQuestionNavHeader';
 import HollandQuestionItem from './components/HollandQuestionItem';
 import Quiz from '../../models/Quiz';
@@ -20,6 +11,7 @@ import { appendAnswer, resetAnswer } from '../../redux/features/quiz/hollandSlic
 import { setCurrentQuiz } from '../../redux/features/quiz/quizSlice';
 import { getQuestions, getForm, getHollandScore } from './services/question_service';
 import SidekiqJob from '../../models/SidekiqJob';
+import {getStyleOfOS} from '../../utils/responsive_util';
 
 export default HollandQuestionnaireScreen = ({route, navigation}) => {
   // Redux
@@ -30,6 +22,8 @@ export default HollandQuestionnaireScreen = ({route, navigation}) => {
   // Pagination and form validation
   const { questions, isPageEnd, page } = getQuestions(route.params?.page);
   const { validationSchema, initialValues } = getForm(questions, currentHollandResponse);
+
+  const scrollY = React.useRef(new Animated.Value(0));
 
   const handleSubmit = (values, {errors}) => {
     dispatch(appendAnswer(values));
@@ -69,13 +63,15 @@ export default HollandQuestionnaireScreen = ({route, navigation}) => {
       onSubmit={ handleSubmit }
       validationSchema={validationSchema}
     >
-      <HollandQuestionNavHeader step={page}/>
-      <ScrollView contentContainerStyle={{flexGrow: 1}}>
-        <View style={{backgroundColor: Color.blue, paddingHorizontal: 16, paddingTop: 8}}>
-          <ProgressStep step={page}/>
-        </View>
+      <HollandQuestionNavHeader step={page} scrollY={scrollY.current}/>
+      <Animated.ScrollView contentContainerStyle={{flexGrow: 1, paddingTop: getStyleOfOS(DeviceInfo.hasNotch() ? 152 : 124, 105)}}
+        onScroll={Animated.event(
+          [{ nativeEvent: { contentOffset: { y: scrollY.current } } }],
+          { useNativeDriver: true },
+        )}
+      >
         {renderContent()}
-      </ScrollView>
+      </Animated.ScrollView>
       <SubmitButton title='បន្តទៀត' />
     </Form>
   )

--- a/app/screens/HollandTest/components/HollandProgressArrow.js
+++ b/app/screens/HollandTest/components/HollandProgressArrow.js
@@ -8,7 +8,7 @@ import { FontSetting } from '../../../assets/style_sheets/font_setting';
 
 const HollandProgressArrow = ({step}) => {
   const progressStepStyles = (index) => {
-    let defaultStyles = { width: 50, height: 18, justifyContent: 'center', width: '100%', position: 'relative' }
+    let defaultStyles = { width: '100%', height: 12, justifyContent: 'center', width: '100%', position: 'relative' }
     if (index == 0)
       defaultStyles = {...defaultStyles, borderTopLeftRadius: 5, borderBottomLeftRadius: 5}
     else if (index == 6)
@@ -22,8 +22,8 @@ const HollandProgressArrow = ({step}) => {
 
     const color = index == (step - 2) ? Color.blue : 'white'
     const points = (index == (step - 1) || index == (step - 2)) ? "20,0 28,15 20,30 18,30 18,0" : "20,0 28,15 20,30 18,30 26,15 18,0"
-    return <Svg height="30" width="30" style={{position: 'absolute', right: -18, top: 0}}>
-              <Polygon points={points} fill={color} scale="0.6" />
+    return <Svg height="30" width="30" style={{position: 'absolute', right: -22, top: 0}}>
+              <Polygon points={points} fill={color} scale="0.4" />
             </Svg>
   }
 
@@ -32,13 +32,13 @@ const HollandProgressArrow = ({step}) => {
       return <View key={`arrow-${index}`} style={{zIndex: 7 - index, flex: 1}}>
                 <View style={progressStepStyles(index)}>
                   {renderArrowHead(index)}
-                  <BoldLabelComponent label={index + 1} style={{marginLeft: 24, paddingTop: 1.5, fontSize: 12, color: index + 1 == step ? Color.blue : 'white'}}/>
+                  <BoldLabelComponent label={index + 1} style={{alignSelf: 'center', marginLeft: 2, paddingTop: 0.3, fontSize: 9, color: index + 1 == step ? Color.blue : 'white'}}/>
                 </View>
              </View>
     })
   }
 
-  return <View style={{height: 40, justifyContent: 'center', backgroundColor: Color.blue, paddingHorizontal: 16}}>
+  return <View style={{height: 24, justifyContent: 'flex-start', backgroundColor: Color.blue, paddingHorizontal: 16, borderWidth: 0}}>
             <View style={{flexDirection: 'row', borderWidth: 1, borderColor: 'white', borderRadius: 6}}>
               {renderArrows()}
             </View>

--- a/app/screens/HollandTest/components/HollandProgressArrow.js
+++ b/app/screens/HollandTest/components/HollandProgressArrow.js
@@ -4,15 +4,14 @@ import Svg, {Polygon} from 'react-native-svg'
 
 import BoldLabelComponent from '../../../components/shared/BoldLabelComponent';
 import Color from '../../../themes/color';
-import { FontSetting } from '../../../assets/style_sheets/font_setting';
 
 const HollandProgressArrow = ({step}) => {
   const progressStepStyles = (index) => {
     let defaultStyles = { width: '100%', height: 12, justifyContent: 'center', width: '100%', position: 'relative' }
     if (index == 0)
-      defaultStyles = {...defaultStyles, borderTopLeftRadius: 5, borderBottomLeftRadius: 5}
+      defaultStyles = {...defaultStyles, borderTopLeftRadius: 3, borderBottomLeftRadius: 3}
     else if (index == 6)
-      defaultStyles = {...defaultStyles, borderTopRightRadius: 5, borderBottomRightRadius: 5}
+      defaultStyles = {...defaultStyles, borderTopRightRadius: 3, borderBottomRightRadius: 3}
 
     return (index + 1 == step) ? {...defaultStyles, backgroundColor: 'white'} : defaultStyles
   }
@@ -24,7 +23,7 @@ const HollandProgressArrow = ({step}) => {
     const points = (index == (step - 1) || index == (step - 2)) ? "20,0 28,15 20,30 18,30 18,0" : "20,0 28,15 20,30 18,30 26,15 18,0"
     return <Svg height="30" width="30" style={{position: 'absolute', right: -22, top: 0}}>
               <Polygon points={points} fill={color} scale="0.4" />
-            </Svg>
+           </Svg>
   }
 
   const renderArrows = () => {
@@ -38,8 +37,8 @@ const HollandProgressArrow = ({step}) => {
     })
   }
 
-  return <View style={{height: 24, justifyContent: 'flex-start', backgroundColor: Color.blue, paddingHorizontal: 16, borderWidth: 0}}>
-            <View style={{flexDirection: 'row', borderWidth: 1, borderColor: 'white', borderRadius: 6}}>
+  return <View style={{height: 24, justifyContent: 'flex-start', paddingTop: 4, backgroundColor: Color.blue, paddingHorizontal: 16}}>
+            <View style={{flexDirection: 'row', borderWidth: 0.5, borderColor: 'white', borderRadius: 4}}>
               {renderArrows()}
             </View>
          </View>

--- a/app/screens/HollandTest/components/HollandProgressArrow.js
+++ b/app/screens/HollandTest/components/HollandProgressArrow.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import {View} from 'react-native'
+import Svg, {Polygon} from 'react-native-svg'
+
+import BoldLabelComponent from '../../../components/shared/BoldLabelComponent';
+import Color from '../../../themes/color';
+import { FontSetting } from '../../../assets/style_sheets/font_setting';
+
+const HollandProgressArrow = ({step}) => {
+  const progressStepStyles = (index) => {
+    let defaultStyles = { width: 50, height: 18, justifyContent: 'center', width: '100%', position: 'relative' }
+    if (index == 0)
+      defaultStyles = {...defaultStyles, borderTopLeftRadius: 5, borderBottomLeftRadius: 5}
+    else if (index == 6)
+      defaultStyles = {...defaultStyles, borderTopRightRadius: 5, borderBottomRightRadius: 5}
+
+    return (index + 1 == step) ? {...defaultStyles, backgroundColor: 'white'} : defaultStyles
+  }
+
+  const renderArrowHead = (index) => {
+    if (index >= 6) return;
+
+    const color = index == (step - 2) ? Color.blue : 'white'
+    const points = (index == (step - 1) || index == (step - 2)) ? "20,0 28,15 20,30 18,30 18,0" : "20,0 28,15 20,30 18,30 26,15 18,0"
+    return <Svg height="30" width="30" style={{position: 'absolute', right: -18, top: 0}}>
+              <Polygon points={points} fill={color} scale="0.6" />
+            </Svg>
+  }
+
+  const renderArrows = () => {
+    return [...Array(7)].map((num, index) => {
+      return <View key={`arrow-${index}`} style={{zIndex: 7 - index, flex: 1}}>
+                <View style={progressStepStyles(index)}>
+                  {renderArrowHead(index)}
+                  <BoldLabelComponent label={index + 1} style={{marginLeft: 24, paddingTop: 1.5, fontSize: 12, color: index + 1 == step ? Color.blue : 'white'}}/>
+                </View>
+             </View>
+    })
+  }
+
+  return <View style={{height: 40, justifyContent: 'center', backgroundColor: Color.blue, paddingHorizontal: 16}}>
+            <View style={{flexDirection: 'row', borderWidth: 1, borderColor: 'white', borderRadius: 6}}>
+              {renderArrows()}
+            </View>
+         </View>
+}
+
+export default HollandProgressArrow

--- a/app/screens/HollandTest/components/HollandQuestionNavHeader.js
+++ b/app/screens/HollandTest/components/HollandQuestionNavHeader.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import {View, StyleSheet} from 'react-native'
+import {Animated, View, StyleSheet} from 'react-native'
 import {Appbar} from 'react-native-paper';
 
-import {BackButton, Text} from '../../../components'
+import {BackButton, Text, ProgressStep} from '../../../components'
 import ConfirmationModal from '../../../components/shared/ConfirmationModal';
 import HollandProgressArrow from './HollandProgressArrow';
 
@@ -34,18 +34,47 @@ const CustomNavigationHeader = (props) => {
             />
   }
 
+  const progressOpacity = props.scrollY.interpolate({
+    inputRange: [0, 60],
+    outputRange: [0, 1],
+    extrapolate: 'clamp'
+  })
+
+  const bigProgresStepOpacity = props.scrollY.interpolate({
+    inputRange: [0, 60],
+    outputRange: [1, 0],
+    extrapolate: 'clamp'
+  })
+
+  const bigProgressStepTranslateY = props.scrollY.interpolate({
+    inputRange: [0, 60],
+    outputRange: [0, -23],
+    extrapolate: 'clamp',
+  })
+
+  const renderProgressIndicator = () => {
+    return <Animated.View style={[{backgroundColor: Color.blue}, { transform: [{ translateY: bigProgressStepTranslateY }] }]}>
+              <Animated.View style={{paddingHorizontal: 16, paddingTop: 6, opacity: bigProgresStepOpacity}}>
+                <ProgressStep step={props.step}/>
+              </Animated.View>
+              <Animated.View style={{opacity: progressOpacity, position: 'absolute', bottom: 4, left: 0, right: 0}}>
+                <HollandProgressArrow step={props.step} />
+              </Animated.View>
+           </Animated.View>
+  }
+
   return (
-    <React.Fragment>
-      <Appbar.Header style={{backgroundColor: Color.blue}}>
+    <View style={styles.header}>
+      <Appbar.Header style={styles.navigation}>
         <View style={{flexDirection: 'row', alignItems: 'center', width: '100%'}}>
           <BackButton onPress={() => !!props.onPressBack ? props.onPressBack() : goBack()} buttonColor={Color.whiteColor} />
           <Appbar.Content title='តេស្តបុគ្គលិកលក្ខណៈ' titleStyle={styles.title} numberOfLines={1} />
           <Appbar.Action icon="home" onPress={() => setModalVisible(true)} color={Color.whiteColor} size={getStyleOfOS(getStyleOfDevice(28, 24), 24)} />
         </View>
       </Appbar.Header>
-      <HollandProgressArrow step={props.step} />
+      {renderProgressIndicator()}
       {renderConfirmation()}
-    </React.Fragment>
+    </View>
   )
 }
 
@@ -54,6 +83,18 @@ const styles = StyleSheet.create({
     color: Color.whiteColor,
     fontFamily: FontFamily.regular,
     fontSize: FontSetting.nav_title,
+  },
+  header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1,
+  },
+  navigation: {
+    backgroundColor: Color.blue,
+    elevation: 0,
+    zIndex: 1,
   }
 })
 

--- a/app/screens/HollandTest/components/HollandQuestionNavHeader.js
+++ b/app/screens/HollandTest/components/HollandQuestionNavHeader.js
@@ -4,6 +4,7 @@ import {Appbar} from 'react-native-paper';
 
 import {BackButton, Text} from '../../../components'
 import ConfirmationModal from '../../../components/shared/ConfirmationModal';
+import HollandProgressArrow from './HollandProgressArrow';
 
 import {goBack, reset} from '../../../hooks/RootNavigation'
 import { FontSetting } from '../../../assets/style_sheets/font_setting';
@@ -42,6 +43,7 @@ const CustomNavigationHeader = (props) => {
           <Appbar.Action icon="home" onPress={() => setModalVisible(true)} color={Color.whiteColor} size={getStyleOfOS(getStyleOfDevice(28, 24), 24)} />
         </View>
       </Appbar.Header>
+      <HollandProgressArrow step={props.step} />
       {renderConfirmation()}
     </React.Fragment>
   )


### PR DESCRIPTION
This pull request creates a progress arrow bar to show under the navigation header of the Holland Questionnaire screen when the user scrolls the content and decreases the font size of the emoji label when opening on the low-pixel mobile.

Below are the screenshots on Android and iOS mobile devices:
[holland questionnaire.zip](https://github.com/ilabsea/trey-visay/files/11731729/holland.questionnaire.zip)
