### PR TITLE
Enhance accordion open only one

### DIFF
--- a/app/components/scrollableHeaders/ScrollableHeaderNavigation.js
+++ b/app/components/scrollableHeaders/ScrollableHeaderNavigation.js
@@ -6,10 +6,10 @@ import CustomNavigationHeader from '../shared/CustomNavigationHeader'
 import {getStyleOfOS, getStyleOfDevice} from '../../utils/responsive_util'
 
 const ScrollableHeaderNavigation = (props) => {
-  if (!props.renderNavigation)
-    return null
+  if (!!props.renderNavigation)
+    return props.renderNavigation()
 
-  return <CustomNavigationHeader headerStyle={styles.bar} buttonColor={props.buttonColor}/>
+  return <CustomNavigationHeader headerStyle={styles.bar} buttonColor={props.buttonColor} onPressBack={props.onPressBack}/>
 }
 
 const iosTop = getStyleOfDevice(29, DeviceInfo.hasNotch() ? 56 : 26)

--- a/app/components/scrollable_header.js
+++ b/app/components/scrollable_header.js
@@ -75,6 +75,7 @@ class ScrollableHeader extends Component {
               headerMaxHeight={this.props.headerMaxHeight}
               renderNavigation={this.props.renderNavigation}
               buttonColor={this.props.buttonColor}
+              onPressBack={this.props.onPressBack}
            />
   }
 

--- a/app/components/shared/CustomNavigationHeader.js
+++ b/app/components/shared/CustomNavigationHeader.js
@@ -3,7 +3,6 @@ import {View, StyleSheet} from 'react-native'
 import {Appbar} from 'react-native-paper';
 
 import {BackButton} from '..'
-import {goBack} from '../../hooks/RootNavigation'
 import { FontSetting } from '../../assets/style_sheets/font_setting';
 import {FontFamily} from '../../themes/font';
 import {navHeaderPaddingTop} from '../../constants/component_constant';
@@ -12,7 +11,7 @@ const CustomNavigationHeader = (props) => {
   return (
     <Appbar.Header style={[styles.header, props.headerStyle]}>
       <View style={{flexDirection: 'row', alignItems: 'center', width: '100%'}}>
-        <BackButton onPress={() => !!props.onPressBack ? props.onPressBack() : goBack()} buttonColor={props.buttonColor} />
+        <BackButton onPress={props.onPressBack} buttonColor={props.buttonColor} />
         <Appbar.Content title={props.title} titleStyle={styles.title} numberOfLines={1} />
       </View>
       {props.children}

--- a/app/components/shared/InfoAccordion.js
+++ b/app/components/shared/InfoAccordion.js
@@ -10,10 +10,10 @@ import { FontSetting } from '../../assets/style_sheets/font_setting';
 import {screenHorizontalPadding} from '../../constants/component_constant';
 
 const InfoAccordion = (props) => {
-  const [statuses, setStatuses] = useState(new Array(props.items.length))
+  const [statuses, setStatuses] = useState(new Array(props.items.length).fill(false))
   const onToggle = (index) => {
-    const newStatuses = statuses
-    newStatuses[index] = !statuses[index];
+    const newStatuses = new Array(props.items.length).fill(false)
+    newStatuses[index] = !statuses[index]
     setStatuses([...newStatuses])
   }
 

--- a/app/screens/HollandTest/HollandDetailScreen.js
+++ b/app/screens/HollandTest/HollandDetailScreen.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 
 import { List } from 'react-native-paper';
-import { Text, BackButton, ScrollableHeader } from '../../components';
+import { Text, ScrollableHeader } from '../../components';
 import HollandTestResultBarChart from '../../components/HollandTestResult/HollandTestResultBarChart';
 import HollandTestResultCharacteristicAccordions from '../../components/HollandTestResult/HollandTestResultCharacteristicAccordions';
 import {screenHorizontalPadding} from '../../constants/component_constant';
@@ -54,9 +54,9 @@ const HollandTestResult = ({route, navigation}) => {
     <View style={{flex: 1}}>
       <ScrollableHeader
         renderContent={ renderContent }
-        renderNavigation={ () => <BackButton onPress={() => navigation.popToTop()} /> }
         title={title}
         largeTitle={title}
+        onPressBack={() => navigation.popToTop()}
       />
     </View>
   )

--- a/app/screens/HollandTest/HollandHomeScreen.js
+++ b/app/screens/HollandTest/HollandHomeScreen.js
@@ -1,15 +1,10 @@
-import React, { Component, useEffect } from 'react';
-import {
-  View,
-  StyleSheet,
-  TouchableOpacity
-} from 'react-native';
+import React from 'react';
+import { View, TouchableOpacity } from 'react-native';
 // import firebase from 'react-native-firebase';
 
 import Color from '../../themes/color';
 import ScrollableHeader from '../../components/scrollable_header';
-import BackButton from '../../components/shared/back_button';
-import { Content, Body, Right, Icon, CardItem } from 'native-base';
+import { Content, Body, CardItem } from 'native-base';
 import ButtonList from '../../components/list/button_list';
 import Text from '../../components/Text';
 import { StartQuizButton, ResumeQuizButton}  from './components';
@@ -89,7 +84,6 @@ const HollandHomeScreen = ({route, navigation}) => {
   return(
     <ScrollableHeader
       renderContent={ renderContent }
-      renderNavigation={ () => <BackButton /> }
       title={title}
       largeTitle={title}
     />

--- a/app/screens/HollandTest/HollandInstructionScreen.js
+++ b/app/screens/HollandTest/HollandInstructionScreen.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { View, Image } from 'react-native'
+import { View, Image, BackHandler } from 'react-native'
+import { useFocusEffect } from '@react-navigation/native';
 
 import Color from '../../themes/color';
 import { Text, FooterBar } from '../../components';
@@ -10,6 +11,17 @@ import ConfirmationModal from '../../components/shared/ConfirmationModal';
 
 const HollandTestInstruction = ({route, navigation}) => {
   const [modalVisible, setModalVisible] = React.useState(false);
+  let backHandler = null
+  useFocusEffect(
+    React.useCallback(() => {
+      backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        navigation.popToTop()
+        return true;
+      })
+      return () => !!backHandler && backHandler.remove()
+    }, [])
+  )
+
   const renderRating = (item, index) => {
     return (
       <View style={{flexDirection: 'row', alignItems: 'center', marginBottom: 16}} key={index}>

--- a/app/screens/HollandTest/HollandInstructionScreen.js
+++ b/app/screens/HollandTest/HollandInstructionScreen.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { View, Image } from 'react-native'
 
 import Color from '../../themes/color';
-import { Text, BackButton, FooterBar } from '../../components';
+import { Text, FooterBar } from '../../components';
 import images from '../../assets/images';
 import ratings from './json/list_ratings';
 import ScrollableHeader from '../../components/scrollable_header';
@@ -37,10 +37,6 @@ const HollandTestInstruction = ({route, navigation}) => {
     )
   }
 
-  const renderNavigation = () => {
-    return (<BackButton buttonColor='#fff' onPress={() => navigation.popToTop()} />)
-  }
-
   return (
     <View style={{flex: 1}}>
       <ScrollableHeader
@@ -49,7 +45,7 @@ const HollandTestInstruction = ({route, navigation}) => {
         statusBarColor={Color.blueStatusBar}
         barStyle={'light-content'}
         renderContent={ renderContent }
-        renderNavigation={ renderNavigation }
+        onPressBack={() => navigation.popToTop()}
         title={'តេស្តបុគ្គលិកលក្ខណៈ'}
         largeTitle={'តេស្តបុគ្គលិកលក្ខណៈ'}
         buttonColor={Color.whiteColor}

--- a/app/screens/HollandTest/HollandTestResultScreen.js
+++ b/app/screens/HollandTest/HollandTestResultScreen.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, TouchableWithoutFeedback } from 'react-native';
 
-import { Text, BackButton, ScrollableHeader, FooterBar } from '../../components';
+import { Text, ScrollableHeader, FooterBar } from '../../components';
 import HollandTestResultBarChart from '../../components/HollandTestResult/HollandTestResultBarChart';
 import HollandTestResultCharacteristicAccordions from '../../components/HollandTestResult/HollandTestResultCharacteristicAccordions';
 import HollandTestResultOptionsBottomSheet from '../../components/HollandTestResult/HollandTestResultOptionsBottomSheet';
@@ -38,9 +38,9 @@ const HollandTestResult = ({navigation}) => {
     <View style={{flex: 1}}>
       <ScrollableHeader
         renderContent={ renderContent }
-        renderNavigation={ () => <BackButton onPress={() => navigation.popToTop()} /> }
         title={title}
         largeTitle={title}
+        onPressBack={() => navigation.popToTop()}
       />
       <FooterBar icon='keyboard-arrow-right' text='បន្តជ្រើសរើសជំនាញសិក្សា ឬអាជីពការងារ' onPress={() => showOptionsBottomSheet()} />
       <BottomSheetModalComponent ref={modalRef} snapPoints={hollandTestResultOptionsSnapPoints} />

--- a/app/screens/HollandTest/HollandTestResultScreen.js
+++ b/app/screens/HollandTest/HollandTestResultScreen.js
@@ -1,5 +1,6 @@
-import React from 'react';
-import { View, TouchableWithoutFeedback } from 'react-native';
+import React, {useEffect} from 'react';
+import { View, TouchableWithoutFeedback, BackHandler } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { Text, ScrollableHeader, FooterBar } from '../../components';
 import HollandTestResultBarChart from '../../components/HollandTestResult/HollandTestResultBarChart';
@@ -15,6 +16,18 @@ const HollandTestResult = ({navigation}) => {
   const currentQuiz = useSelector((state) => state.currentQuiz.value);
   const modalRef = React.useRef();
   const title = "តេស្តបុគ្គលិកលក្ខណៈ"
+  let backHandler = null
+
+  useFocusEffect(
+    React.useCallback(() => {
+      backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        navigation.popToTop()
+        return true;
+      })
+      return () => !!backHandler && backHandler.remove()
+    }, [])
+  )
+
   const renderContent = () => {
     return (
       <TouchableWithoutFeedback>

--- a/app/screens/PersonalUnderstanding/PersonalUnderstandingTest.js
+++ b/app/screens/PersonalUnderstanding/PersonalUnderstandingTest.js
@@ -4,7 +4,7 @@ import {
   Platform,
 } from 'react-native';
 
-import { FooterBar, BackButton, ScrollableHeader } from '../../components';
+import { ScrollableHeader } from '../../components';
 import Color from '../../themes/color';
 import Toast, { DURATION } from 'react-native-easy-toast';
 import keyword from '../../data/analytics/keyword';
@@ -40,10 +40,6 @@ export default PersonalUnderstandingTest = ({navigation}) => {
     return (<QuestionForm />)
   }
 
-  const renderNavigation = () => {
-    return (<BackButton buttonColor='#fff' onPress={() => navigation.popToTop()} />)
-  }
-
   const handleSubmit = (values, {resetForm}) => {
     if (!!values && !Object.keys(values).length) {
       return toastRef.current?.show('សូមបំពេញសំណួរខាងក្រោមជាមុនសិន...!', DURATION.SHORT);
@@ -74,10 +70,10 @@ export default PersonalUnderstandingTest = ({navigation}) => {
           statusBarColor={Color.blueStatusBar}
           barStyle={'light-content'}
           renderContent={ renderContent }
-          renderNavigation={ renderNavigation }
           title={'ស្វែងយល់ពីខ្លួនឯង'}
           largeTitle={'ស្វែងយល់ពីខ្លួនឯង'}
           buttonColor={Color.whiteColor}
+          onPressBack={() => navigation.popToTop()}
         />
 
         { <SubmitButton title="បន្តទៀត"/> }

--- a/app/screens/PersonalUnderstanding/PersonalUnderstandingTest.js
+++ b/app/screens/PersonalUnderstanding/PersonalUnderstandingTest.js
@@ -1,8 +1,6 @@
 import React, {Component, useRef, useEffect} from 'react';
-import {
-  View,
-  Platform,
-} from 'react-native';
+import { View, Platform, BackHandler} from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { ScrollableHeader } from '../../components';
 import Color from '../../themes/color';
@@ -35,6 +33,17 @@ export default PersonalUnderstandingTest = ({navigation}) => {
   const dispatch = useDispatch();
   const toastRef = useRef();
   const currentQuiz = useSelector((state) => state.currentQuiz.value);
+  let backHandler = null
+
+  useFocusEffect(
+    React.useCallback(() => {
+      backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        navigation.popToTop()
+        return true;
+      })
+      return () => !!backHandler && backHandler.remove()
+    }, [])
+  )
 
   const renderContent = () => {
     return (<QuestionForm />)

--- a/app/screens/profile/Form.js
+++ b/app/screens/profile/Form.js
@@ -156,7 +156,6 @@ const FormScreen = ({onSubmit}) => {
             <ScrollableHeader
               style={{backgroundColor: '#fff'}}
               renderContent={ () => renderContent(values) }
-              renderNavigation={ () => <BackButton /> }
               title={title}
               largeTitle={title}
             />


### PR DESCRIPTION
This pull request makes some enhancements to the accordion and screen navigation as listed below:
- Allow the accordion to expand its content only one at a time
- Enhance the navigation header and Android back button  of the Holland test result, Holland instruction, and Personal understanding test screen to redirect to the Holland home screen
- Enhancement to the scrollable header and makes some changes to the screen that are using the scrollable header component.