### PR TITLE
Enhance then confirmation button to render the left button in outline…

### DIFF
--- a/app/components/shared/ConfirmationModals/ConfirmationModalButtons.js
+++ b/app/components/shared/ConfirmationModals/ConfirmationModalButtons.js
@@ -1,21 +1,25 @@
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
-import {Button} from 'native-base';
+import { Button } from 'react-native-paper';
 
-import Text from '../../Text';
 import Color from '../../../themes/color';
+import {FontFamily} from '../../../themes/font';
+import {FontSetting} from '../../../assets/style_sheets/font_setting';
 import {pressableItemSize, buttonBorderRadius} from '../../../constants/component_constant';
 
 const ConfirmationModalButtons = (props) => {
-  const renderButton = (label, onPress, style) => {
-    return <Button style={[styles.btn, style]} onPress={() => onPress()}>
-              <Text style={{color: Color.whiteColor}}>{label}</Text>
+  const renderButton = (label, mode, onPress, style) => {
+    return <Button mode={mode} style={[styles.btn, style]} onPress={() => onPress()} textColor={mode == 'outlined' ? Color.pressable : Color.whiteColor}
+              labelStyle={{fontFamily: FontFamily.regular, fontSize: FontSetting.text}}
+              contentStyle={{minWidth: 70, height: pressableItemSize}}
+           >
+              {label}
            </Button>
   }
 
   return <View style={styles.container}>
-            { !!props.leftButtonLabel && renderButton(props.leftButtonLabel, props.onLeftPress, {marginRight: 22}) }
-            { !!props.rightButtonLabel && renderButton(props.rightButtonLabel, props.onRightPress) }
+            { !!props.leftButtonLabel && renderButton(props.leftButtonLabel, 'outlined', props.onLeftPress, {marginRight: 16, borderColor: Color.pressable, borderWidth: 1.5}) }
+            { !!props.rightButtonLabel && renderButton(props.rightButtonLabel, 'contained', props.onRightPress, {backgroundColor: Color.pressable}) }
           </View>
 }
 
@@ -26,12 +30,8 @@ const styles = StyleSheet.create({
   },
   btn: {
     alignItems: 'center',
-    backgroundColor: Color.pressable,
     borderRadius: buttonBorderRadius,
     justifyContent: 'center',
-    height: pressableItemSize,
-    minWidth: pressableItemSize,
-    paddingHorizontal: 18
   }
 });
 

--- a/app/screens/HollandTest/components/StartQuizButton.js
+++ b/app/screens/HollandTest/components/StartQuizButton.js
@@ -48,6 +48,7 @@ const StartQuizButton = () => {
         rightButtonLabel='ចូលគណនីថ្មី'
         onLeftPress={goToPersonalUnderstandingTest}
         onRightPress={goToNewProfile}
+        onDismiss={() => setVisible(false)}
       />
       <AppButton style={styles.button} onPress={() => getStart() }>
         <Text style={styles.btnText}>ធ្វើតេស្តថ្មី</Text>


### PR DESCRIPTION
This pull request enhances the UI of the confirmation modal button to render the left button in outline style and allows to press on the backdrop to close the Holland home confirmation modal.

Below are the screenshots of the confirmation modal after updated:
[confirmation modal.zip](https://github.com/ilabsea/trey-visay/files/11741146/confirmation.modal.zip)
