### PR TITLE
Decrease the margin and make the progress arrow stick to navigation h…

### DIFF
--- a/app/screens/HollandTest/components/HollandProgressArrow.js
+++ b/app/screens/HollandTest/components/HollandProgressArrow.js
@@ -8,11 +8,6 @@ import Color from '../../../themes/color';
 const HollandProgressArrow = ({step}) => {
   const progressStepStyles = (index) => {
     let defaultStyles = { width: '100%', height: 12, justifyContent: 'center', width: '100%', position: 'relative' }
-    if (index == 0)
-      defaultStyles = {...defaultStyles, borderTopLeftRadius: 3, borderBottomLeftRadius: 3}
-    else if (index == 6)
-      defaultStyles = {...defaultStyles, borderTopRightRadius: 3, borderBottomRightRadius: 3}
-
     return (index + 1 == step) ? {...defaultStyles, backgroundColor: 'white'} : defaultStyles
   }
 
@@ -37,10 +32,8 @@ const HollandProgressArrow = ({step}) => {
     })
   }
 
-  return <View style={{height: 24, justifyContent: 'flex-start', paddingTop: 4, backgroundColor: Color.blue, paddingHorizontal: 16}}>
-            <View style={{flexDirection: 'row', borderWidth: 0.5, borderColor: 'white', borderRadius: 4}}>
-              {renderArrows()}
-            </View>
+  return <View style={{flexDirection: 'row', borderWidth: 0.8, borderColor: 'white', borderLeftWidth: 0, borderRightWidth: 0, backgroundColor: Color.blue}}>
+            {renderArrows()}
          </View>
 }
 

--- a/app/screens/HollandTest/components/HollandQuestionNavHeader.js
+++ b/app/screens/HollandTest/components/HollandQuestionNavHeader.js
@@ -34,7 +34,7 @@ const CustomNavigationHeader = (props) => {
             />
   }
 
-  const progressOpacity = props.scrollY.interpolate({
+  const progressArrowOpacity = props.scrollY.interpolate({
     inputRange: [0, 60],
     outputRange: [0, 1],
     extrapolate: 'clamp'
@@ -48,7 +48,7 @@ const CustomNavigationHeader = (props) => {
 
   const bigProgressStepTranslateY = props.scrollY.interpolate({
     inputRange: [0, 60],
-    outputRange: [0, -23],
+    outputRange: [0, -33],
     extrapolate: 'clamp',
   })
 
@@ -57,7 +57,7 @@ const CustomNavigationHeader = (props) => {
               <Animated.View style={{paddingHorizontal: 16, paddingTop: 6, opacity: bigProgresStepOpacity}}>
                 <ProgressStep step={props.step}/>
               </Animated.View>
-              <Animated.View style={{opacity: progressOpacity, position: 'absolute', bottom: 4, left: 0, right: 0}}>
+              <Animated.View style={{opacity: progressArrowOpacity, position: 'absolute', bottom: 0, left: 0, right: 0}}>
                 <HollandProgressArrow step={props.step} />
               </Animated.View>
            </Animated.View>


### PR DESCRIPTION
This pull request removes the margin of the progress arrow and makes it stick to the bottom of the navigation header.

Below are the screenshots on Android mobile devices: 
[progress arrow.zip](https://github.com/ilabsea/trey-visay/files/11741442/progress.arrow.zip)
