### PR TITLE
Adjust the horizontal margin of the emoji items in the Holland questi…

### DIFF
--- a/app/components/HollandTest/Rating.js
+++ b/app/components/HollandTest/Rating.js
@@ -1,18 +1,21 @@
 import React from 'react'
-import { View, Image, TouchableHighlight } from 'react-native'
+import { View, Image } from 'react-native'
 import Color from '../../themes/color';
 import { Text } from '../../components';
 import images from '../../assets/images';
+import {isShortWidthScreen} from '../../utils/responsive_util';
 
 const Rating = (props) => {
-  const style = props.active ? {backgroundColor: Color.blue} : {};
+  const style = props.active ? {borderColor: Color.blue, borderWidth: 2} : {};
 
   return (
-    <View style={[{padding: 8, borderWidth: 1, borderRadius: 5, marginRight: 16, borderColor: Color.gray}, style]}>
-      <Image
-        source={ images[props.icon] }
-        style={[{width: 50, height: 50}, props.style]}
-      />
+    <View style={[{borderWidth: 1, borderRadius: 5, borderColor: Color.gray, height: 95, flexDirection: 'column'}, style]}>
+      <View style={{flex: 1, justifyContent: 'flex-end', alignItems: 'center'}}>
+        <Image source={ images[props.icon] } style={[{width: 50, height: 50}, props.style]} />
+      </View>
+      <View style={{flex: 1, justifyContent: 'center', alignItems: 'center', borderWidth: 0}}>
+        <Text style={{fontSize: isShortWidthScreen() ? 11 : 12, width: '100%', textAlign: 'center', lineHeight: 18, paddingHorizontal: 2}}>{props.label}</Text>
+      </View>
     </View>
   )
 }

--- a/app/components/HollandTest/RatingGroup.js
+++ b/app/components/HollandTest/RatingGroup.js
@@ -3,8 +3,7 @@ import { View, TouchableOpacity } from 'react-native'
 import Rating from './Rating';
 import { useFormikContext } from "formik";
 import ErrorMessage from '../forms/ErrorMessage';
-import Text from '../Text';
-import {isShortWidthScreen} from '../../utils/responsive_util';
+import {getStyleOfOS} from '../../utils/responsive_util';
 
 const RatingGroup = ({name, options}) => {
   const { setFieldValue, values, errors, touched, isSubmitting } = useFormikContext();
@@ -14,21 +13,19 @@ const RatingGroup = ({name, options}) => {
     return (
       <TouchableOpacity onPress={() => {
         setFieldValue(name, rating.value);
-      }} key={index} style={{justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap'}}>
-        <Text style={{fontSize: isShortWidthScreen() ? 11 : 12}}>{rating.name}</Text>
-        <Rating icon={rating.icon} style={{width: 40, height: 40}} active={rating.value == value} />
+      }} key={index} style={{flex: 1, flexDirection: 'column', marginTop: getStyleOfOS(2, 0), marginRight: index == options.length - 1 ? 0 : 10}}>
+        <Rating icon={rating.icon} style={{width: 40, height: 40}} active={rating.value == value} label={rating.name} />
       </TouchableOpacity>
     )
   }
 
   return (
-    <View>
-      <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
+    <React.Fragment>
+      <View style={{flexDirection: 'row', width: '100%'}}>
         { options.map(renderRating) }
       </View>
-
-      <ErrorMessage error={errors[name]} visible={touched[name]} style={{marginLeft: 16}} />
-    </View>
+      <ErrorMessage error={errors[name]} visible={touched[name]} />
+    </React.Fragment>
   )
 }
 

--- a/app/components/HollandTest/RatingGroup.js
+++ b/app/components/HollandTest/RatingGroup.js
@@ -23,7 +23,7 @@ const RatingGroup = ({name, options}) => {
 
   return (
     <View>
-      <View style={{flexDirection: 'row'}}>
+      <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
         { options.map(renderRating) }
       </View>
 

--- a/app/components/shared/ConfirmationModals/ConfirmationModalButtons.js
+++ b/app/components/shared/ConfirmationModals/ConfirmationModalButtons.js
@@ -10,7 +10,7 @@ import {pressableItemSize, buttonBorderRadius} from '../../../constants/componen
 const ConfirmationModalButtons = (props) => {
   const renderButton = (label, mode, onPress, style) => {
     return <Button mode={mode} style={[styles.btn, style]} onPress={() => onPress()} textColor={mode == 'outlined' ? Color.pressable : Color.whiteColor}
-              labelStyle={{fontFamily: FontFamily.regular, fontSize: FontSetting.text}}
+              labelStyle={{fontFamily: FontFamily.regular, fontWeight: 'normal', fontSize: FontSetting.text}}
               contentStyle={{minWidth: 70, height: pressableItemSize}}
            >
               {label}

--- a/app/screens/HollandTest/components/HollandQuestionItem.js
+++ b/app/screens/HollandTest/components/HollandQuestionItem.js
@@ -6,9 +6,9 @@ import ratings from '../json/list_ratings';
 
 export default HollandQuestionItem = ({question, index}) => {
   return (
-    <Card key={index} style={{marginVertical: 8, padding: 8}} >
+    <Card key={index} style={{marginVertical: 8, padding: 8, paddingTop: 4}}>
       <Text style={{marginHorizontal: 6}}>{index + 1}) {question.name}</Text>
-      <View style={{alignItems: 'center'}}>
+      <View style={{paddingHorizontal: 8}}>
         <RatingGroup name={question.code} options={ratings}/>
       </View>
     </Card>

--- a/app/screens/HollandTest/components/HollandQuestionItem.js
+++ b/app/screens/HollandTest/components/HollandQuestionItem.js
@@ -7,8 +7,7 @@ import ratings from '../json/list_ratings';
 export default HollandQuestionItem = ({question, index}) => {
   return (
     <Card key={index} style={{marginVertical: 8, padding: 8}} >
-      <Text>{index + 1}) {question.name}</Text>
-
+      <Text style={{marginHorizontal: 6}}>{index + 1}) {question.name}</Text>
       <View style={{alignItems: 'center'}}>
         <RatingGroup name={question.code} options={ratings}/>
       </View>


### PR DESCRIPTION
This pull request makes UI enhancement to the Holland Questionnaire screen:
- Move the emoji label into the emoji box
- Adjust the margin of the emoji box to prevent it from getting stuck to the screen border when opening on the low-pixel mobile devices
- Change the style of the selected emoji item to have a blue border (outline style) instead of having a blue background
- Set the font weight of the confirmation modal button to normal to fix the style when open on iOS devices

Below are the screenshots on the Android and iOS mobile devices:
[questionnaire.zip](https://github.com/ilabsea/trey-visay/files/11743415/questionnaire.zip)


