### PR TITLE
Enhance the UI of the personal understanding radio buttons and checkb…

### DIFF
--- a/app/components/forms/Checkbox.js
+++ b/app/components/forms/Checkbox.js
@@ -20,13 +20,13 @@ const MyCheckbox = (props) => {
 
   return (
     <View style={{flexDirection: 'row', alignItems: 'center'}}>
-      <Checkbox
+      <Checkbox.Android
         status={ checked ? 'checked' : 'unchecked' }
         onPress={ onPress }
         color={ Colors.blue }
       />
 
-      <TouchableOpacity onPress={onPress} style={{flex: 1}}>
+      <TouchableOpacity onPress={onPress} style={{flex: 1, marginLeft: 10}}>
         <Text>{props.label}</Text>
       </TouchableOpacity>
     </View>

--- a/app/components/forms/RadioGroup.js
+++ b/app/components/forms/RadioGroup.js
@@ -21,7 +21,7 @@ const RadioGroup = ({name, options, disabled}) => {
   const buttonGroups = () => (
     options.map((option, i) =>
       <View key={i} style={{flexDirection: 'row', alignItems: 'center', borderBottomWidth: i == options.length - 1 ? 0 : 0.5, borderColor: Color.gray, height: pressableItemSize}}>
-        <RadioButton
+        <RadioButton.Android
           status={ value == option.value ? "checked" : "unchecked" }
           value={ option.value }
           color={ Colors.blue }
@@ -30,7 +30,7 @@ const RadioGroup = ({name, options, disabled}) => {
         />
 
         <TouchableWithoutFeedback onPress={() => onValueChange(option.value)}>
-          <View style={{flex: 1, justifyContent: 'center', height: '100%'}}>
+          <View style={{flex: 1, justifyContent: 'center', height: '100%', marginLeft: 10}}>
             <Text style={getTextStyle}>{option.name}</Text>
           </View>
         </TouchableWithoutFeedback>


### PR DESCRIPTION
This pull request enhances the UI of the personal understanding radio buttons and checkboxes on iOS to look the same as on Android and increases the margin-left of the radio button and checkbox label.

These are the screenshot of the personal understanding screen running on the iPhone:
<img src='https://github.com/ilabsea/trey-visay/assets/18114944/89d1f33b-d65a-47c6-9449-87b8f4ff9343' width='280'/>
<img src='https://github.com/ilabsea/trey-visay/assets/18114944/11460d38-3ee6-4545-8d33-c145919d02b1' width='280' />
