### PR TITLE
Update the navigation of the Other screen

### DIFF
--- a/app/components/scrollableHeaders/ScrollableHeaderMain.js
+++ b/app/components/scrollableHeaders/ScrollableHeaderMain.js
@@ -95,7 +95,7 @@ const styles = StyleSheet.create({
   titleWrapper: {
     position: 'absolute',
     left: NAVIGATION_BUTTON_WIDTH,
-    right: NAVIGATION_BUTTON_WIDTH,
+    // right: NAVIGATION_BUTTON_WIDTH,
     bottom: getStyleOfOS(iosTitleBottom, -5),
     justifyContent: 'center',
     height: getStyleOfOS('auto', DEFAULT_HEADER_MIN_HEIGHT),

--- a/app/components/scrollable_header.js
+++ b/app/components/scrollable_header.js
@@ -105,7 +105,7 @@ class ScrollableHeader extends Component {
       <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
         <React.Fragment>
           { this.renderStatusBar() }
-          { this.renderNavigation()} 
+          { !this.props.hideNavigation && this.renderNavigation()} 
           { this.renderContent() }
           { this.renderHeader() }
         </React.Fragment>

--- a/app/navigations/OtherNavigator.js
+++ b/app/navigations/OtherNavigator.js
@@ -16,7 +16,7 @@ const Stack = createNativeStackNavigator();
 function OtherNavigator() {
   return (
     <Stack.Navigator screenOptions={{headerShown: false}} initialRouteName="Others">
-      <Stack.Screen name="Others" component={Others} />
+      <Stack.Screen name="OthersScreen" component={Others} />
       <Stack.Screen name="About" component={About} />
       <Stack.Screen name="TermsCondition" component={TermsCondition} />
     </Stack.Navigator>

--- a/app/screens/Others/Others.js
+++ b/app/screens/Others/Others.js
@@ -4,6 +4,7 @@ import {
   StatusBar,
   Platform
 } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
 import ButtonList from '../../components/list/button_list';
 import Color from '../../themes/color';
 import ScrollableHeader from '../../components/scrollable_header';
@@ -13,6 +14,7 @@ import Share from 'react-native-share';
 import keyword from '../../data/analytics/keyword';
 import useAuth from "../../auth/useAuth";
 import { useNavigation } from '@react-navigation/native';
+import {getStyleOfOS} from '../../utils/responsive_util';
 
 export default function Others(props) {
   const { user, logOut } = useAuth();
@@ -57,13 +59,13 @@ export default function Others(props) {
             hasLine={true}
             icon={{color: 'rgb(53, 174, 235)', src: require('../../assets/icons/others/share.png')}}
             onPress={() => onPressShareApp() }
-            title='Share App' />
+            title='ចែករំលែកកម្មវិធី' />
 
           <ButtonList
             hasLine={true}
             icon={{color: 'rgb(172, 175, 193)', src: require('../../assets/icons/others/term_condition.png')}}
             onPress={() => { navigation.navigate('TermsCondition') }}
-            title='Terms & Conditions' />
+            title='គោលការណ៏ និងលក្ខខណ្ឌ' />
         </View>
 
       </View>
@@ -75,6 +77,9 @@ export default function Others(props) {
       renderContent={ renderContent }
       title={'ផ្សេងៗ'}
       largeTitle={'ផ្សេងៗ'}
+      hideNavigation={true}
+      headerMaxHeight={getStyleOfOS(DeviceInfo.hasNotch() ? 80 : 85, 60)}
+      style={{marginTop: getStyleOfOS(DeviceInfo.hasNotch() ? 40 : 17, 0)}}
     />
   )
 }

--- a/app/screens/TermsCondition/TermsCondition.js
+++ b/app/screens/TermsCondition/TermsCondition.js
@@ -31,7 +31,7 @@ export default class TermsCondition extends Component {
   }
 
   render() {
-    let title = 'Terms & Conditions';
+    let title = 'គោលការណ៏ និងលក្ខខណ្ឌ';
     return (
       <ScrollableHeader
         style={{backgroundColor: '#fff'}}


### PR DESCRIPTION
This pull request makes adjustments to the scrollable header and makes some enhancements to the Other screen as listed below:
- Update the UI of the navigation header of the Other screen
- Change the label of the "Share App" and "Terms and Conditions" to "ចែករំលែកកម្មវិធី" and "គោលការណ៏ និងលក្ខខណ្ឌ" in the Other screen
- Resolve the warning of duplicate screen naming
- Move the title of the scrollable header to the left side when the content is scrolled in order to make it consistent with the other navigation header (on iOS devices)

Below are the screenshots of the Other screen on iOS and Android devices:
[other screen.zip](https://github.com/ilabsea/trey-visay/files/11893156/other.screen.zip)
