### PR TITLE
Fix the style of the test history item in Holland Home screen and upd…

### DIFF
--- a/app/screens/HollandTest/HollandDetailScreen.js
+++ b/app/screens/HollandTest/HollandDetailScreen.js
@@ -37,7 +37,7 @@ const HollandTestResult = ({route, navigation}) => {
 
   const renderContent = () => {
     return (
-      <View style={{marginBottom: 10}}>
+      <View style={{marginBottom: 25}}>
         <View style={{paddingTop: 10, paddingHorizontal: screenHorizontalPadding}}>
           <Text style={{color: 'black', lineHeight: getStyleOfOS(30, 34)}}>ខាងក្រោមនេះ ជាលទ្ធផលតេស្ដរបស់អ្នក! សូមអ្នកឈ្វេងយល់ពីការពណ៌នាលម្អិតអំពីបុគ្គលិកលក្ខណៈរបស់អ្នកដូចខាងក្រោម </Text>
           <HollandTestResultBarChart quiz={currentQuiz}/>

--- a/app/screens/HollandTest/HollandHomeScreen.js
+++ b/app/screens/HollandTest/HollandHomeScreen.js
@@ -7,6 +7,7 @@ import ScrollableHeader from '../../components/scrollable_header';
 import { Body, CardItem } from 'native-base';
 import ButtonList from '../../components/list/button_list';
 import Text from '../../components/Text';
+import BoldLabelComponent from '../../components/shared/BoldLabelComponent';
 import { StartQuizButton, ResumeQuizButton}  from './components';
 import QuizListItem from './components/QuizListItem';
 import useAuth from "../../auth/useAuth";
@@ -37,7 +38,7 @@ const HollandHomeScreen = ({route, navigation}) => {
 
     return (
       <View style={{padding: 16}}>
-        <Text>លទ្ធផលធ្វើតេស្ត</Text>
+        <BoldLabelComponent label="លទ្ធផលធ្វើតេស្ត" />
 
         { quizzes.map((quiz, i) =>
           (

--- a/app/screens/HollandTest/components/QuizListItem.js
+++ b/app/screens/HollandTest/components/QuizListItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import mainStyles from '../../../assets/style_sheets/main/main';
+import {FontSetting} from '../../../assets/style_sheets/font_setting';
 import Color from '../../../themes/color';
 import { longDateFormat as dateFormat } from '../../../utils/date';
 import {getStyleOfOS} from '../../../utils/responsive_util';
@@ -22,7 +23,7 @@ const QuizListItem = ({number, quiz, onPress}) => {
         </View>
 
         <View style={styles.textWrapper}>
-          <Text style={[mainStyles.title, {lineHeight: 42}]}>តេស្តលើកទី {kmNumber}</Text>
+          <Text style={[mainStyles.title, {lineHeight: 42, fontSize: FontSetting.big_title}]}>តេស្តលើកទី {kmNumber}</Text>
           <Text style={[mainStyles.subTitle, {flex: 1}]}>ធ្វើនៅ: {dateFormat(quiz.createdAt)}</Text>
         </View>
 
@@ -36,7 +37,7 @@ const QuizListItem = ({number, quiz, onPress}) => {
 const styles = StyleSheet.create({
   number: {
     width: 60,
-    height: 99,
+    minHeight: 99,
     borderRightWidth: 1,
     borderRightColor: Color.blue,
     alignItems: 'center',


### PR DESCRIPTION
This pull request fixes the style break on iPhone with a notch and enhances some styles as listed below:
- Fix the style break of the Holland test history item on iPhone with a notch
- Update the Holland test history section title to bold text and increase the font size of the title in the test history card item
- Increase the margin-bottom of the Holland Detail screen so the bottom item will not be blocked on the iPhone with a notch