### PR TITLE
Reduce image size of home tilted card

### DIFF
--- a/app/api/client.js
+++ b/app/api/client.js
@@ -3,7 +3,7 @@ import { environment } from '../config/environment';
 
 const apiClient = create({
   baseURL: environment.baseURL,
-  headers: {'Authorization': `Token ${environment.apiKey}`}
+  headers: {'Authorization': `Token ${environment.backendApiKey}`}
 });
 
 export default apiClient;

--- a/app/assets/style_sheets/mobile/horizontalCardComponentStyles.js
+++ b/app/assets/style_sheets/mobile/horizontalCardComponentStyles.js
@@ -2,18 +2,19 @@ import { StyleSheet } from 'react-native';
 import {cardBorderRadius} from '../../../constants/component_constant';
 import color from '../../../themes/color';
 import {FontSetting} from '../../../assets/style_sheets/font_setting';
+import {isShortScreenDevice} from '../../../utils/responsive_util';
 
 const horizontalCardComponentStyles = StyleSheet.create({
   container: {
     borderRadius: cardBorderRadius,
-    height: 110,
+    height: isShortScreenDevice () ? 95 : 110,
     paddingHorizontal: 12,
     width: '100%',
   },
   labelContainer: {
     flex: 1,
     justifyContent: 'center',
-    paddingHorizontal: 8
+    paddingHorizontal: 4,
   },
   title: {
     fontSize: FontSetting.text

--- a/app/assets/style_sheets/mobile/horizontalCardImageComponentStyles.js
+++ b/app/assets/style_sheets/mobile/horizontalCardImageComponentStyles.js
@@ -1,5 +1,7 @@
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
 import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import DeviceInfo from 'react-native-device-info';
+import {isShortScreenDevice} from '../../../utils/responsive_util';
 
 const HorizontalCardImageComponentStyles = StyleSheet.create({
   container:{
@@ -7,8 +9,16 @@ const HorizontalCardImageComponentStyles = StyleSheet.create({
     width: wp('22%'),
   },
   image: {
-    width: 90,
-    height: 86,
+    ...Platform.select({
+      android: {
+        width: '94%',
+        height: '65%',
+      },
+      ios: {
+        width: DeviceInfo.hasNotch() ? '92%' : '92%',
+        height: DeviceInfo.hasNotch() ? '55%' : isShortScreenDevice() ? '60%' : '55%',
+      }
+    })
   }
 });
 

--- a/app/assets/style_sheets/mobile/titledCardComponentStyles.js
+++ b/app/assets/style_sheets/mobile/titledCardComponentStyles.js
@@ -1,4 +1,6 @@
 import {StyleSheet, Platform} from 'react-native';
+import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import DeviceInfo from 'react-native-device-info';
 import color from '../../../themes/color';
 import componentUtil from '../../../utils/component_util';
 import {isLowPixelDensityDevice, isShortScreenDevice} from '../../../utils/responsive_util';
@@ -6,9 +8,17 @@ import {FontSetting} from '../../../assets/style_sheets/font_setting';
 
 const tiltedCardComponentStyles = StyleSheet.create({
   container: {
-    maxHeight: isShortScreenDevice() ? 140 : 155,
     width: componentUtil.getGridCardWidth(),
-    borderRadius: 70
+    borderRadius: 70,
+    borderTopLeftRadius: 100,
+    ...Platform.select({
+      ios: {
+        maxHeight: DeviceInfo.hasNotch() ? hp('14%') : hp('15%'),
+      },
+      android: {
+        maxHeight: isShortScreenDevice() ? hp('14.5%') : hp('15%'),
+      }
+    }),
   },
   tiltedView: {
     backgroundColor: color.whiteColor,
@@ -22,7 +32,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
     ...Platform.select({
       ios: {
         borderBottomRightRadius: 40,
-        top: isLowPixelDensityDevice() ? -5.5 : -7,
+        top: isLowPixelDensityDevice() ? -5.5 : -7.4,
         right: -2.9
       },
       android: {
@@ -48,6 +58,7 @@ const tiltedCardComponentStyles = StyleSheet.create({
     backgroundColor: color.whiteColor,
     borderRadius: 10,
     borderTopRightRadius: 0,
+    elevation: 1,
     flexDirection: 'column',
     flexGrow: 1,
   },

--- a/app/components/shared/cards/CardItemComponent.js
+++ b/app/components/shared/cards/CardItemComponent.js
@@ -19,7 +19,7 @@ export default function CardListComponent({item, onPress}) {
       default:
         return <TiltedCardComponent
                   item={item}
-                  containerStyle={{marginTop: getStyleOfDevice(68, 46)}}
+                  containerStyle={{marginTop: getStyleOfDevice(68, 50), elevation: 0}}
                   onPress={onPress}
                 />
     }

--- a/app/components/shared/cards/HorizontalCard/HorizontalCardImageComponent.js
+++ b/app/components/shared/cards/HorizontalCard/HorizontalCardImageComponent.js
@@ -10,7 +10,7 @@ const styles = getStyleOfDevice(tabletStyles, mobileStyles);
 const HorizontalCardImageComponent = (props) => {
   return (
     <View style={styles.container}>
-    <Image source={props.image} resizeMode='center' style={styles.image} />
+      <Image source={props.image} resizeMode='contain' style={styles.image} />
     </View>
   )
 }

--- a/app/components/shared/cards/TitledCard/TitledCardImageComponent.js
+++ b/app/components/shared/cards/TitledCard/TitledCardImageComponent.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {View, StyleSheet, Image} from 'react-native';
-import {getStyleOfDevice} from '../../../../utils/responsive_util'
+import {View, StyleSheet, Image, Platform} from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+import {getStyleOfDevice, isShortScreenDevice} from '../../../../utils/responsive_util'
 
 const TitledCardImageComponent = (props) => {
   return <View style={{flex: 1.5}}>
@@ -10,11 +11,19 @@ const TitledCardImageComponent = (props) => {
 
 const styles = StyleSheet.create({
   image: {
-    height: getStyleOfDevice(125, 115),
-    width: '100%',
     top: -46,
     zIndex: 1,
-    borderColor: 'black',
+    alignSelf: 'center',
+    ...Platform.select({
+      android: {
+        height: getStyleOfDevice(125, isShortScreenDevice() ? 80 : 85),
+        width: isShortScreenDevice() ? '70%' : '75%',
+      },
+      ios: {
+        height: getStyleOfDevice(125, DeviceInfo.hasNotch() ? 85 : 78),
+        width: DeviceInfo.hasNotch() ? '75%' : '70%',
+      }
+    })
   }
 });
 

--- a/app/config/environment.example.js
+++ b/app/config/environment.example.js
@@ -7,5 +7,5 @@ export const environment = {
   maxFailedAttempt: 3,
   baseURL: 'http://192.168.1.145:3000/api/v1',
   sentryDSN: '',
-  apiKey: '',
+  backendApiKey: '',
 };


### PR DESCRIPTION
This pull request reduces the image and the card item size on the Home screen in order to be able to render it on one screen without scrolling. And updates the environment variable name from "apiKey" to "backendApiKey".

Below are the screenshots of the Home screen on Android and iPhone:
[Treyvisay home screen.zip](https://github.com/ilabsea/trey-visay/files/12518616/Treyvisay.home.screen.zip)

This is a screenshot of iPhone 14 after updated to render the card label in one line
<img src="https://github.com/ilabsea/trey-visay/assets/18114944/d6fd8bfe-0264-420d-a808-65d37f7a57f8" width="300" height="670"
 />

