### PR TITLE
Enhance career website web view

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:usesCleartextTraffic="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/app/screens/CareerWebsite/WebviewScreen.js
+++ b/app/screens/CareerWebsite/WebviewScreen.js
@@ -2,28 +2,57 @@ import React, {Component} from 'react';
 import { View, Platform } from 'react-native';
 import { WebView } from 'react-native-webview';
 import DeviceInfo from 'react-native-device-info';
+import NetInfo from '@react-native-community/netinfo';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import LoadingIndicator from '../../components/loading_indicator';
 import CustomNavigationHeader from '../../components/shared/CustomNavigationHeader'
+import Text from '../../components/Text';
+import color from '../../themes/color';
+import {FontSetting} from '../../assets/style_sheets/font_setting';
 
 export default class WebviewScreen extends Component {
   constructor(props) {
     super(props);
-    this.state = { loading: true }
+    this.state = {
+      loading: true,
+      hasInternet: false,
+    }
+  }
+
+  componentDidMount() {
+    this.netInfoUnsubscribe = NetInfo.addEventListener(state => {
+      this.setState({hasInternet: state.isConnected && state.isInternetReachable})
+    });
+  }
+
+  componentWillUnmount() {
+    !!this.netInfoUnsubscribe && this.netInfoUnsubscribe();
+  }
+
+  renderWebview() {
+    return <WebView
+              ref="webviewRef"
+              style={{flex: 1}}
+              source={{ uri: this.props.route.params.url || 'http://nea.gov.kh/index.do' }}
+              javaScriptEnabled={true}
+              domStorageEnabled={true}
+              onLoadEnd={ () => this.setState({loading: false}) }
+            />
+  }
+
+  renderNoConnectionMessage() {
+    return <View style={{flex: 1, backgroundColor: 'white', zIndex: 2, justifyContent: 'center', alignItems: 'center'}}>
+              <Icon name="wifi-off" size={60} color={color.gray} />
+              <Text style={{color: color.gray, fontSize: FontSetting.title}}>មិនមានប្រព័ន្ធអ៊ីនធឺណិត</Text>
+           </View>
   }
 
   render() {
     return(
       <View style={{flex: 1, paddingBottom: (Platform.OS == 'ios' && DeviceInfo.hasNotch()) ? 22 : 0, backgroundColor: 'white'}}>
         <CustomNavigationHeader title={this.props.route.params.title} headerStyle={{zIndex: 2}} />
-        <WebView
-          ref="webviewRef"
-          style={{flex: 1}}
-          source={{ uri: this.props.route.params.url || 'http://nea.gov.kh/index.do' }}
-          javaScriptEnabled={true}
-          domStorageEnabled={true}
-          onLoadEnd={ () => this.setState({loading: false}) }
-        />
+        { this.state.hasInternet ? this.renderWebview() : this.renderNoConnectionMessage() }
 
         {
           this.state.loading &&

--- a/ios/TreyVisay/Info.plist
+++ b/ios/TreyVisay/Info.plist
@@ -26,6 +26,8 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>
@@ -36,7 +38,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
+	<string></string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
This pull request makes some enhancements to the career website web view screen as follows:
- Show a no internet connection message instead of the default error message of the web view library when the device has no internet connection
- Resolve the issue of not being able to view some websites (ex: http://nea.gov.kh/index.do) on both Android and iOS

Below is the screenshots of the no internet message:
<img src="https://github.com/ilabsea/trey-visay/assets/18114944/e72f95ad-2ee7-46b1-ace6-d2974a97da09" width="330" height="650" />
