### PR TITLE
Add timeout when loading the career website list after syncing

### DIFF
--- a/app/screens/CareerWebsite/CareerWebsiteHomeScreen.js
+++ b/app/screens/CareerWebsite/CareerWebsiteHomeScreen.js
@@ -42,9 +42,11 @@ export default class CareerWebsiteHomeScreen extends Component {
 
   onRefresh() {
     this.listIndex = itemsPerPage;
-    careerWebsiteService.syncData((careerWebsites) => {
-      this.setState({careerWebsites: careerWebsites});
-      this.listRef.current?.stopRefreshLoading();
+    careerWebsiteService.syncData(() => {
+      setTimeout(() => {
+        this.setState({careerWebsites: CareerWebsite.getAll()});
+        this.listRef.current?.stopRefreshLoading();
+      }, 1000);
     });
   }
 

--- a/app/services/career_website_service.js
+++ b/app/services/career_website_service.js
@@ -17,8 +17,8 @@ const careerWebsiteService = (() => {
           asyncStorageService.setItem('CAREER_WEBSITE_UPDATED_AT', newUpdatedAt);
         });
       })
-      !!callback && callback(CareerWebsite.getAll());
-    }, (error) => !!callback && callback(CareerWebsite.getAll()) )
+      !!callback && callback();
+    }, (error) => !!callback && callback() )
   }
 })();
 


### PR DESCRIPTION
This pull request adds the timeout when loading the career website data after syncing in order to make the list get updated in every pull to refresh.